### PR TITLE
Fix YAML duplicate keys issue

### DIFF
--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -117,8 +117,3 @@ resilience4j.ratelimiter:
       limitRefreshPeriod: 1m
       timeoutDuration: 0s
 
-spring:
-  redis:
-    host: 170.106.99.35
-    port: 6379
-    password: your-password


### PR DESCRIPTION
Related to #5

Merge duplicate `spring` keys in YAML configuration files.

* Remove duplicate `spring` key in `application/src/main/resources/application.yaml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/StevenChen16/Halo-2.20.9/pull/6?shareId=1845d472-1f71-4886-aa06-09422ae80b08).